### PR TITLE
Pass configuration to InlineRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # CHANGELOG
 
+## 0.1.10
+
+- FIX: pass configuration to `InlineRenderer` as well
+
 ## 0.1.9
 
-* `#to_stripped_s` removes leading & trailing white-space (null, horizontal tab, line feed, vertical tab, form feed, carriage return, space) using Ruby's `#strip`
+- `#to_stripped_s` removes leading & trailing white-space (null, horizontal tab, line feed, vertical tab, form feed, carriage return, space) using Ruby's `#strip`
 
 ## 0.1.8
 
-* Mongoid 7 compatibility
+- Mongoid 7 compatibility

--- a/lib/mongoid_markdown_extension/markdown.rb
+++ b/lib/mongoid_markdown_extension/markdown.rb
@@ -74,7 +74,11 @@ module MongoidMarkdownExtension
 
     # TODO: how to combine custom render class with the InlineRenderer?
     def markdown_inline_renderer
-      Redcarpet::Markdown.new(InlineRenderer, tables: false)
+      render_options = MongoidMarkdownExtension::Markdown.configuration.render_options
+      extensions = MongoidMarkdownExtension::Markdown.configuration.extensions
+      extensions[:tables] = false
+
+      Redcarpet::Markdown.new(InlineRenderer.new(render_options), extensions)
     end
 
     def markdown_stripdown_renderer

--- a/mongoid_markdown_extension.gemspec
+++ b/mongoid_markdown_extension.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'redcarpet', '~> 3.4'
   spec.add_dependency 'mongoid', '>= 4.0', '< 8'
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
We don't pass the configuration options to `InlineRenderer`, which can lead to some unexpected differences in the result of `#to_html` and `#to_inline_html`.