### PR TITLE
Add line_breaks option for #to_inline_html

### DIFF
--- a/lib/mongoid_markdown_extension/inline_renderer.rb
+++ b/lib/mongoid_markdown_extension/inline_renderer.rb
@@ -41,7 +41,7 @@ module MongoidMarkdownExtension
     end
 
     def paragraph(text)
-      text + '<br /><br />'
+      text + '<br><br>'
     end
   end
 end

--- a/lib/mongoid_markdown_extension/markdown.rb
+++ b/lib/mongoid_markdown_extension/markdown.rb
@@ -50,8 +50,10 @@ module MongoidMarkdownExtension
       markdown_renderer.render(@str).html_safe
     end
 
-    def to_inline_html
-      markdown_inline_renderer.render(@str).gsub(/(<br\s?\/?>)+?\Z/, '').html_safe
+    def to_inline_html(line_breaks: false)
+      rendered = markdown_inline_renderer.render(@str).gsub(/(<br\s?\/?>)+?\z/, '')
+      rendered.gsub!(/(<br\s?\/?>)+?\Z/, '') if !line_breaks
+      rendered.html_safe
     end
 
     def to_stripped_s

--- a/test/mongoid_markdown_extension/markdown_test.rb
+++ b/test/mongoid_markdown_extension/markdown_test.rb
@@ -72,6 +72,7 @@ module MongoidMarkdownExtension
 
     describe '#to_inline_html' do
       let(:string) { "some text with _italic_\n\nfoo" }
+      let(:string_with_line_breaks) { "some text with line break  \nfoo" }
 
       it 'survives nil' do
         MongoidMarkdownExtension::Markdown.new(nil).to_inline_html.must_equal ''
@@ -81,8 +82,15 @@ module MongoidMarkdownExtension
         subject.to_inline_html.wont_include '<p>'
       end
 
-      it 'replaces <p> with <br />' do
-        subject.to_inline_html.must_equal 'some text with <em>italic</em><br /><br />foo'
+      it 'replaces <p> with <br>' do
+        subject.to_inline_html.must_equal 'some text with <em>italic</em><br><br>foo'
+      end
+
+      it 'allows line breaks' do
+        MongoidMarkdownExtension::Markdown
+          .new(string_with_line_breaks)
+          .to_inline_html(line_breaks: true)
+          .must_equal "some text with line break<br>\nfoo"
       end
     end
 


### PR DESCRIPTION
This PR adds a `line_breaks` option for `MongoidMarkdownExtension::Markdown#to_inline_html`.