### PR TITLE
Fix to_inline_html

### DIFF
--- a/lib/mongoid_markdown_extension/markdown.rb
+++ b/lib/mongoid_markdown_extension/markdown.rb
@@ -46,7 +46,7 @@ module MongoidMarkdownExtension
     end
 
     def to_inline_html(line_breaks: false)
-      rendered = markdown_inline_renderer.render(@str).gsub(/(<br\s?\/?>)+?\z/, '')
+      rendered = markdown_inline_renderer.render(to_s).gsub(/(<br\s?\/?>)+?\z/, '')
       rendered.gsub!(/(<br\s?\/?>)+?\Z/, '') if !line_breaks
       rendered.html_safe
     end

--- a/test/mongoid_markdown_extension/markdown_test.rb
+++ b/test/mongoid_markdown_extension/markdown_test.rb
@@ -84,14 +84,14 @@ module MongoidMarkdownExtension
       end
 
       it 'replaces <p> with <br>' do
-        subject.to_inline_html.must_equal 'some text with <em>italic</em><br><br>foo'
+        _(subject.to_inline_html).must_equal 'some text with <em>italic</em><br><br>foo'
       end
 
       it 'allows line breaks' do
-        MongoidMarkdownExtension::Markdown
+        inline_html = MongoidMarkdownExtension::Markdown
           .new(string_with_line_breaks)
           .to_inline_html(line_breaks: true)
-          .must_equal "some text with line break<br>\nfoo"
+        _(inline_html).must_equal "some text with line break<br>\nfoo"
       end
     end
 


### PR DESCRIPTION
Fixes an outdated call to `@str`, which was removed in a later PR.