### PR TITLE
InlineRenderer: replace paragraph with postprocess

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ matrix:
       env: MONGOID_VERSION=5
     - rvm: 2.3.3
       env: MONGOID_VERSION=6
-    - rvm: 2.5.7
+    - rvm: 2.7.2
       env: MONGOID_VERSION=7

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ notifications:
 
 matrix:
   include:
-    - rvm: 2.3.3
+    - rvm: 2.7.2
       env: MONGOID_VERSION=4
-    - rvm: 2.3.3
+    - rvm: 2.7.2
       env: MONGOID_VERSION=5
-    - rvm: 2.3.3
+    - rvm: 2.7.2
       env: MONGOID_VERSION=6
     - rvm: 2.7.2
       env: MONGOID_VERSION=7

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ matrix:
       env: MONGOID_VERSION=5
     - rvm: 2.3.3
       env: MONGOID_VERSION=6
-    - rvm: 2.5.0
+    - rvm: 2.5.7
       env: MONGOID_VERSION=7

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ notifications:
 
 matrix:
   include:
-    - rvm: 2.7.2
+    - rvm: 2.3.3
       env: MONGOID_VERSION=4
-    - rvm: 2.7.2
+    - rvm: 2.3.3
       env: MONGOID_VERSION=5
     - rvm: 2.7.2
       env: MONGOID_VERSION=6

--- a/lib/mongoid_markdown_extension/inline_renderer.rb
+++ b/lib/mongoid_markdown_extension/inline_renderer.rb
@@ -40,8 +40,11 @@ module MongoidMarkdownExtension
       nil
     end
 
-    def paragraph(text)
-      text + '<br><br>'
+    def postprocess(full_document)
+      full_document
+        .gsub(/(<\/p>\s*<p>)+?/, '<br><br>')
+        .gsub(/(<\/?p>)+?/, '')
+        .chop
     end
   end
 end


### PR DESCRIPTION
This allows the `:hard_wrap` rendering option to survive inline rendering.